### PR TITLE
Add initial PEP draft

### DIFF
--- a/proto_pep_notes.rst
+++ b/proto_pep_notes.rst
@@ -9,7 +9,7 @@ Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 2020-05-04
-Python version: 3.10
+Python-Version: 3.10
 Resolution:
 
 Abstract
@@ -332,8 +332,8 @@ building blocks. The following patterns are supported:
 
   Whether a match succeeds or not is determined by calling a special
   ``__match__()`` method on the class named in the pattern
-  (`Point` or `Rectangle` in the example),
-  with the value being matched (`shape`) as the only argument.
+  (``Point`` and ``Rectangle`` in the example),
+  with the value being matched (``shape``) as the only argument.
   If the method returns ``None``, the match fails, otherwise the
   match continues w.r.t. attributes of the returned proxy object, see details
   in `runtime`_ section.


### PR DESCRIPTION
As briefly discussed in #20 here is an initial PEP draft. I essentially took some chunks from my notes and tried to glue them together using my understanding of current best approximation to consensus.

I think I didn't include any ingredients where at least a partial agreement isn't reached. The only exception is whether to raise by default + one-off matches, where currently situation is 50/50 IIUC. Mostly because I already had some text on this and I like it :-)

I also included a selection of rejected ideas, I was not sure about some of them, we can probably complete this section later. I propose that we take this draft as starting point and then improve it progressively as we find consensus on more details.