### PR TITLE
Disallowed float and one-off syntax

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -217,9 +217,7 @@ boolean, or ``None``::
 
 Literal pattern uses equality with literal on the right hand side, so that
 in the above example ``number == 1`` and then possibly ``number == 2`` will
-be evaluated. Note that ``float`` and ``complex`` numbers are not allowed
-as literals in patterns (due to their trickiness with imprecise 
-representation and rounding). Also, although technically negative numbers 
+be evaluated. Note that although technically negative numbers 
 are represented by an unary operation expression, they are considered 
 literals for the purpose of pattern matching. Raw strings and byte strings 
 are supported. F-strings are not allowed (since in general they are not 


### PR DESCRIPTION
Apart from typos, this PR includes two proposals:
- Saying that floats are not allowed seems a bit ambiguous to me and I would be more precise in saying that they are not allowed _as literals_, even when this can be inferred from context.  After all, I think we will certainly allow something like `match 3.1415: ...`, but not `case 3.1415: ...`.
- The idea of a one-off form is currently strongly tied to using `if` as a keyword.  As discussed in #21, we could also go without the `if`.  I tried to change the PEP so to better reflect that the `if` would be just one possible option, but that this is more about the idea and less about a concrete syntax variant.