### PR TITLE
Switch from 'as' to 'case'.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1252,8 +1252,6 @@ as equivalent to the following expansion::
   match value:
       case pattern [if guard]:
           ...
-      case _:
-          pass  # Note: not raising UnmatchedValue exception here
 
 Even in the variant ``if match``, there will be no ``elif match`` statements 
 allowed. One-off match is special case of ``match`` statement, not a special 


### PR DESCRIPTION
I have changed the syntax of the examples so that they use `case` now instead of `as`.

I have also updated the paragraph on using an alternative keyword and slightly expanded it to not only include `as`, but also other variants like `with` or `|`, etc.

Some of the arguments in the original PEP were dropped entirely, namely that `as` would be fewer keystrokes and that `case` would be too similar to `switch` whereas `as` better expresses the concept.  The latter I would say is captured by the discussion of merging two different concepts with our pattern matching.  And the number of keystrokes does not seem too relevant here because `case` is not long enough a word to cause an issue (I feel that familiarity with a word is more important in this context).