### PR TITLE
Fix tab completion in binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -32,7 +32,8 @@ echo 'alias python=python3.10' >> ~/.bashrc
 python3.10 -m pip install -r $HOME/requirements.pip
 
 # Install IPython as kernel with our 3.10 Python. Note - currently this
-# requires builds from master of both ipython and pyzmq.
+# requires builds from master of both ipython and pyzmq, and parso (for jedi)
+python3.10 -m pip install git+https://github.com/davidhalter/parso
 python3.10 -m pip install git+https://github.com/ipython/ipython
 python3.10 -m pip install Cython 
 python3.10 -m pip install git+https://github.com/zeromq/pyzmq


### PR DESCRIPTION
There was a bug in parso that was making it choke on the version number `3.10a1` and fail to provide any tab completion. 

This has been fixed in master, so installing this in the binder will restore tab completion in Jupyter notebook... at least in the cells with a valid Python 3.6 Syntax (parso does not understand 3.10 yet, and currently fallback on 3.6 syntax I believe), which is still an improvement.

cc @fperez 

Binder currently (re)building after rebased, once built can be tried at https://mybinder.org/v2/gh/carreau/patma/parso?urlpath=lab