### PR TITLE
Use 3.8's self-documenting f-strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ match point:
     case (0, 0):
         print("Origin")
     case (0, y):
-        print(f"Y={y}")
+        print(f"{y=}")
     case (x, 0):
-        print(f"X={x}")
+        print(f"{x=}")
     case (x, y):
-        print(f"X={x}, Y={y}")
+        print(f"{x=}, {y=}")
     case _:
         raise ValueError("Not a point")
 ```
@@ -121,9 +121,9 @@ def whereis(point):
         case Point(0, 0):
             print("Origin")
         case Point(0, y):
-            print(f"Y={y}")
+            print(f"{y=}")
         case Point(x, 0):
-            print(f"X={x}")
+            print(f"{x=}")
         case Point():
             print("Somewhere else")
         case _:


### PR DESCRIPTION
The most minor of changes, 3.8 introduced [self-documenting](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging) f-strings for debugging.

I feel they have a place in the code example(s) in the README as it's their exact usecase.