### PR TITLE
Fix small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Several other key features:
 - Mapping patterns: `{"bandwidth": b, "latency": l}` captures the
   `"bandwidth"` and `"latency"` values from a dict.  Unlike sequence
   patterns, extra keys are ignored.  A wildcard `**rest` is also
-  supported.  (But `**_` would be redundant, so it not allowed.)
+  supported.  (But `**_` would be redundant, so it is not allowed.)
 
 - Subpatterns may be captured using the `as` operator:
 


### PR DESCRIPTION
Fixes a small typo in README.md by adding in a missing "is".