### PR TITLE
Fix match_args in the expr example

### DIFF
--- a/examples/expr.py
+++ b/examples/expr.py
@@ -50,7 +50,7 @@ class TokenStream:
 # Note definition of __match_args__ to support sequence destructuring.
 class BinaryOp:
     """A binary operator expression."""
-    __match_args__ = ["op", "left", "right"]
+    __match_args__ = ("op", "left", "right")
 
     PRECEDENCE = {
         '+': 3,


### PR DESCRIPTION
I get this error before the modification:

```
TypeError:` BinaryOp.__match_args__ must be a tuple (got list)
```

The version of my python is `Python 3.10.0rc2`.