### PR TITLE
[binder] Fix typo in widgets list

### DIFF
--- a/binder/workspace.json
+++ b/binder/workspace.json
@@ -23,7 +23,7 @@
           "command-palette",
           "jp-property-inspector",
           "tab-manager",
-          "jupuyerlab-toc",
+          "jupyterlab-toc",
           "extensionmanager.main-view"
         ]
       },


### PR DESCRIPTION
Unfortunately, seems, this typo has not been fixed in https://github.com/gvanrossum/patma/commit/9f055b91cc394675bef88e87ffc8ee842e2cad75